### PR TITLE
Allow govcms sites to use twig_tweak

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "simesy/whitelist",
     "description": "Specify composer packages for whitelisting only",
     "require": {
-        "drupal/block_field": "~1"
+        "drupal/block_field": "~1",
+        "drupal/twig_tweak": "~2"
     }
 }


### PR DESCRIPTION
Fixes #1 